### PR TITLE
Better the hitpoint calculation and change to Vector2

### DIFF
--- a/PhysicsCones.cs
+++ b/PhysicsCones.cs
@@ -17,7 +17,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static RaycastHit ConeCast(Vector2 origin, Vector2 direction, float coneAngle, float maxDistance, 
+    public static RaycastHit ConeCast(Vector3 origin, Vector3 direction, float coneAngle, float maxDistance, 
                                         int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         float maxRadius = Mathf.Abs(Mathf.Tan(coneAngle * Mathf.Deg2Rad) * maxDistance);
@@ -37,7 +37,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static RaycastHit ConeCast(Vector2 origin, float maxRadius, Vector2 direction, float maxDistance, 
+    public static RaycastHit ConeCast(Vector3 origin, float maxRadius, Vector3 direction, float maxDistance, 
                                         int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         // if maxDistance is infinite then we can't figure out a max radius size. 
@@ -72,7 +72,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static RaycastHit[] ConeCastAll(Vector2 origin, Vector2 direction, float coneAngle, float maxDistance,
+    public static RaycastHit[] ConeCastAll(Vector3 origin, Vector3 direction, float coneAngle, float maxDistance,
                                             int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         float maxRadius = Mathf.Abs(Mathf.Tan(coneAngle * Mathf.Deg2Rad) * maxDistance);
@@ -92,7 +92,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static RaycastHit[] ConeCastAll(Vector2 origin, float maxRadius, Vector2 direction, float maxDistance,
+    public static RaycastHit[] ConeCastAll(Vector3 origin, float maxRadius, Vector3 direction, float maxDistance,
                                              int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         // if maxDistance is infinite then we can't figure out a max radius size. 
@@ -123,7 +123,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static int ConeCastNonAlloc(Vector2 origin, Vector2 direction, float coneAngle, RaycastHit[] results, float maxDistance,
+    public static int ConeCastNonAlloc(Vector3 origin, Vector3 direction, float coneAngle, RaycastHit[] results, float maxDistance,
                                        int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         float maxRadius = Mathf.Abs(Mathf.Tan(coneAngle * Mathf.Deg2Rad) * maxDistance);
@@ -144,7 +144,7 @@ public static class PhysicsCones
     /// <param name="minDepth">Only include objects with a Z coordinate (depth) greater than or equal to this value.</param>
     /// <param name="maxDepth">Only include objects with a Z coordinate (depth) less than or equal to this value.</param>
     /// <returns></returns>
-    public static int ConeCastNonAlloc(Vector2 origin, float maxRadius, Vector2 direction, RaycastHit[] results, float maxDistance,
+    public static int ConeCastNonAlloc(Vector3 origin, float maxRadius, Vector3 direction, RaycastHit[] results, float maxDistance,
                                        int mask = Physics.DefaultRaycastLayers, QueryTriggerInteraction queryTriggerInteraction = QueryTriggerInteraction.UseGlobal)
     {
         // if maxDistance is infinite then we can't figure out a max radius size. 

--- a/PhysicsCones.cs
+++ b/PhysicsCones.cs
@@ -177,7 +177,13 @@ public static class PhysicsCones
         int j = 0;  // variable to keep track of the number of accepted results
         for (int i = 0; i < numResults; i++)
         {
-            Vector3 hitPoint = results[i].point;
+            Collider hitCollider = results[i].collider;
+            Vector3 hitPos = hitCollider.transform.position;
+            // Calculate the closest point on ray by projecting the vector origin->centerOfCollider on vector direction
+            Vector3 closestPointOnRay = Vector3.Project((hitPos - origin), direction) + origin;
+            // Ask unity the closest point on the collider from the point on the ray we just got
+            Vector3 hitPoint = hitCollider.ClosestPoint(closestPointOnRay);
+
             Vector3 directionToHit = hitPoint - origin;
             float angleToHit = Vector3.Angle(direction, directionToHit);
 


### PR DESCRIPTION
Switched from Vector2 to Vector3, as we are in 3D.

Improved the hitpoint calculation, as with a SphereCast, we must pay attention to:
**SphereCast will not detect colliders for which the sphere overlaps the collider. Passing a zero radius results in undefined output and doesn't always behave the same as Physics.Raycast.**

We calculate the closest point on the ray (direction of the spherecast) to the center of the collider. Then we ask Unity to give us the closest point from it on the collider. We consider this new point as our Hit point and use it for further calculation.
